### PR TITLE
fix for navigation sucking on small (read: laptop) screens

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -824,6 +824,12 @@ nav {
   margin-left: -580px;
   text-align: right;
 }
+@media screen and (max-height: 800px){
+  nav {
+    position: absolute; 
+    top: 0;
+  }
+} 
 nav ul {
   list-style: none;
   list-style-image: none;


### PR DESCRIPTION
Commit title explains the fix really, using media queries to adjust the position property of the nav based on the height of the window.
