### PR TITLE
Update plugins.jade

### DIFF
--- a/app/plugins.jade
+++ b/app/plugins.jade
@@ -58,6 +58,8 @@ block content
     <a href="https://github.com/sandy98/wisp-brunch">wisp-brunch</a>. Adds support for <a href="https://github.com/Gozala/wisp">Wisp</a>, which is a cute Clojure-like Lisp.</li>
     <li>
     <a href="https://github.com/darthapo/react-brunch">react-brunch</a>. Adds support for <a href="http://facebook.github.io/react/">React</a> templates.</li>
+    <li>
+    <a href="https://github.com/gcollazo/es6-module-transpiler-brunch">es6-module-transpiler-brunch</a>. Adds ES6 module syntax support via <a href="https://github.com/square/es6-module-transpiler">es6-module-transpiler</a>.</li>
     </ul><h3>
     <a name="style-languages" class="anchor" href="#style-languages"><span class="octicon octicon-link"></span></a>Style languages</h3>
 


### PR DESCRIPTION
Adds es6-module-transpiler-brunch under the Script languages section.
