### PR TITLE
Update plugins.jade

### DIFF
--- a/app/plugins.jade
+++ b/app/plugins.jade
@@ -189,6 +189,8 @@ block content
     <li>
     <a href="https://github.com/meleyal/git-digest-brunch">git-digest-brunch</a> - cache busts urls using the SHA digest of the current git revision.</li>  
     <li>
+    <a href="https://github.com/BoLaMN/hg-digest-brunch">hg-digest-brunch</a> - cache busts urls using the current mercurial revision.</li>  
+    <li>
     <a href="https://github.com/ktmud/yaml-i18n-brunch">yaml-i18n-brunch</a> - use yaml to edit i18n translations.</li>
     <li>
     <a href="https://github.com/Tomtomgo/constangular-brunch">constangular-brunch</a> - environment aware YAML configurations for AngularJS.</li>


### PR DESCRIPTION
adding https://github.com/BoLaMN/hg-digest-brunch, a mercurial version of git-digest-brunch.
