### PR TITLE
Move search CTA from top of page to bottom

### DIFF
--- a/app/plugins.jade
+++ b/app/plugins.jade
@@ -26,6 +26,10 @@ block content
       for more docs on packages.
     </p>
 
+    <p>
+      Search for <a href="https://www.npmjs.org/search?q=brunch">brunch on npm</a> for even more plug-ins.
+    </p>
+
     <div class="markdown-body">
 
     <h1>

--- a/app/plugins.jade
+++ b/app/plugins.jade
@@ -18,7 +18,7 @@ block content
     </p>
 
     <p>
-      To install new plugin, simply execute <code>npm install --save plugin-name</code>. This will install its node.js dependencies and save to <code>package.json</code>. Search for <a href="https://www.npmjs.org/search?q=brunch">brunch on npm</a> for even more plug-ins.
+      To install new plugin, simply execute <code>npm install --save plugin-name</code>. This will install its Node.js dependencies and save them to <code>package.json</code>.
     </p>
 
     <p>To remove it, edit <code>package.json</code>’s <code>dependencies</code> hash.
@@ -213,4 +213,7 @@ block content
     <a href="https://github.com/Tomtomgo/constangular-brunch">constangular-brunch</a> - environment aware YAML configurations for AngularJS.</li>
     <li><a href="https://github.com/pierr/package-brunch">package-brunch</a> - Appends a js file containing configuration information.</li>
     </ul>
+    <p>
+      Search for <a href="https://www.npmjs.org/search?q=brunch">brunch on npm</a> for even more plug-ins.
+    </p>
     </div>


### PR DESCRIPTION
Users may not notice the search link at the top of the page and hit a dead-end when they get to the bottom. Moving the NPM search link to the bottom will give them a good place to continue exploring for plug-ins.