### PR TITLE
Remove autoprefixer-brunch from plugin list

### DIFF
--- a/app/plugins.jade
+++ b/app/plugins.jade
@@ -97,8 +97,6 @@ block content
     <li>
     <a href="https://github.com/iamvdo/postcss-brunch">PostCSS Brunch</a> Compiles a project using <a href="https://github.com/ai/postcss">PostCSS</a> (a CSS postprocessor). Add as many PostCSS based polyfills as you want (like Autoprefixer)</li>
     <li>
-    <a href="https://github.com/lydell/autoprefixer-brunch">autoprefixer-brunch</a>. <a href="https://github.com/ai/autoprefixer">autoprefixer</a> parses plain CSS and takes care of all vendor prefixes, using data from the <a href="http://caniuse.com/">Can I use...</a> compatibility tables.</li>
-    <li>
     <a href="https://github.com/garetht/csscomb-brunch">csscomb-brunch</a>. <a href="http://http://csscomb.com/">CSSComb</a> sorts your CSS properties in a specified order and keeps related properties together.</li>
     <li>
     <a href="https://github.com/jas/stylus-spritesmith-brunch">stylus-spritesmith-brunch</a>. Adds Stylus support with <a href="http://visionmedia.github.com/nib/">nib</a> and sprite sheet generation via <a href="https://github.com/Ensighten/spritesmith">Spritesmith</a>.</li>


### PR DESCRIPTION
It is deprecated in favor of postcss-brunch.