### PR TITLE
Added glslify-brunch to plugins

### DIFF
--- a/app/plugins.jade
+++ b/app/plugins.jade
@@ -74,6 +74,8 @@ block content
     <a href="https://github.com/e-jigsaw/sweet-js-brunch">sweet-js-brunch</a>. Adds support for <a href="http://sweetjs.org/">sweet.js</a>.</li>
     <li>
     <a href="https://github.com/yavorsky/riot-brunch">riot-brunch</a>. Adds support for <a href="https://muut.com/riotjs/">Riot</a>, a React-like, 2.5kb user interface library.</li>
+    <li>
+    <a href="https://github.com/bmatcuk/glslify-brunch">glslify-brunch</a>. Transpile GLSL to javascript strings through <a href="https://github.com/stackgl/glslify">glslify</a>, a node-like module system for GLSL.</li>
     </ul>
 
     <h3>


### PR DESCRIPTION
glslify-brunch transpiles GLSL to javascript strings via glslify, a node-like module system for GLSL.