### PR TITLE
Add fingerprint-brunch plugin

### DIFF
--- a/app/plugins.jade
+++ b/app/plugins.jade
@@ -222,6 +222,8 @@ block content
     <li>
     <a href="https://github.com/BoLaMN/hg-digest-brunch">hg-digest-brunch</a> - cache busts urls using the current mercurial revision.</li>
     <li>
+    <a href="https://github.com/dlepaux/fingerprint-brunch">fingerprint-brunch</a> - rename desired generated files with a unique SHA and generate a map file</li>
+    <li>
     <a href="https://github.com/ktmud/yaml-i18n-brunch">yaml-i18n-brunch</a> - use yaml to edit i18n translations.</li>
     <li>
     <a href="https://github.com/Tomtomgo/constangular-brunch">constangular-brunch</a> - environment aware YAML configurations for AngularJS.</li>


### PR DESCRIPTION
fingerprint-brunch is a plugin like grunt-hash. It rename assets you want with a SHA and make a map of renamed files.
I did this plugin because digest-brunch is based on a completly different method...
I'm open to any suggestions ! Thank you