### PR TITLE
add html-brunch-static

### DIFF
--- a/app/plugins.jade
+++ b/app/plugins.jade
@@ -182,6 +182,8 @@ block content
     <li>
     <a href="https://github.com/slattery/static-underscore-brunch">Static-underscore-brunch</a> — same, but for underscore.js.</li>
     <li>
+    <a href="https://github.com/bmatcuk/html-brunch-static">html-brunch-static</a> - Compile static html with support for layouts, partial views, and multiple languages such as markdown, jade, handlebars, etc.</li>
+    <li>
     <a href="https://github.com/jcruz2us/docco-brunch">Docco-brunch</a> — adds <a href="http://jashkenas.github.com/docco/">Docco</a> documentation generator for your <code>app/</code> directory.</li>
     <li>
     <a href="https://github.com/MazeMap/jsdoc-brunch">JSDoc-brunch</a> — adds <a href="https://github.com/jsdoc3/jsdoc">JSDoc</a> documentation generator for your <code>app/</code> directory.</li>


### PR DESCRIPTION
html-brunch-static transpiles markdown, jade, handlebars, and other languages into static html files with support for layouts and partial views.