### PR TITLE
Fix mdPath in docs layout

### DIFF
--- a/source/app/assets/_layouts/_docs.jade
+++ b/source/app/assets/_layouts/_docs.jade
@@ -40,7 +40,7 @@ block main
           .grid__item.one-whole
               - var _split = filename.split('/')
               - var mdName = _split[_split.length - 1].replace('.jade', '.md')
-              - var mdPath = 'app/assets/_docs/' + mdName
+              - var mdPath = 'source/app/assets/_docs/' + mdName
               - var ghUrl = 'https://github.com/brunch/brunch.github.io/tree/master/' + mdPath;
               span.note
                 a(href=ghUrl) Edit #{mdName} on GitHub


### PR DESCRIPTION
All of the edit links in the documentation are broken; a quick fix to the `mdPath` should resolve things.