### PR TITLE
Fix typo on the plugins page for HMR-brunch copy [Closes 206]

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -12,7 +12,7 @@
       "name": "HMR-brunch",
       "url": "brunch/hmr-brunch",
       "category": "Others",
-      "description": "Allows to use Hot Module Replacement in your Brunch porjects."
+      "description": "Allows to use Hot Module Replacement in your Brunch projects."
     },
     {
       "name": "CoffeeScript",


### PR DESCRIPTION
Now looks like this:
<img width="659" alt="screen shot 2016-12-08 at 11 41 04 pm" src="https://cloud.githubusercontent.com/assets/4997781/21037941/db846eaa-bd9f-11e6-965a-325870711ead.png">
