### PR TITLE
Fix typo on the docs/using-modules page

### DIFF
--- a/docs/using-modules.html
+++ b/docs/using-modules.html
@@ -54,7 +54,7 @@ Additionally, most of the docs will assume you use CommonJS.</p>
 <h3 id="using-node-modules">Using node modules</h3>
 <p>NPM integration is enabled by default starting Brunch 2.3 so there&#39;s no additional setup!
 Simply <code>npm install --save</code> your front-end packages as you normally would, <code>require</code> them in your app, and Brunch will figure out the rest.</p>
-<p>Just make sure that your don&#39;t forget to join <code>/^node_modules/</code> somewhere!</p>
+<p>Just make sure that you don&#39;t forget to join <code>/^node_modules/</code> somewhere!</p>
 <pre><code class="lang-javascript">files: {
   javascripts: {
     joinTo: {


### PR DESCRIPTION
I found a small spelling error on the docs page, so I'm submitting a fix for it.