### PR TITLE
Remove suggestion to use CoffeeScript

### DIFF
--- a/docs/config.html
+++ b/docs/config.html
@@ -385,11 +385,6 @@ Possible values:</p>
 </ul>
 </li>
 </ul>
-<h2 id="tips">Tips</h2>
-<ul>
-<li>You can use CoffeeScript to write configuration files. This way they&#39;ll be
-much shorter and concise. Simply create a file called <code>brunch-config.coffee</code>.</li>
-</ul>
 <div class="container doc-nav"><div class="grid"><div class="grid__item one-whole lap-and-up-one-half"><a href="/docs/commands">&larr; Commands</a></div><div style="text-align: right;" class="grid__item one-whole lap-and-up-one-half"><a href="/docs/plugins">Plugin API &rarr;</a></div><div class="grid__item one-whole"><span class="note"><a href="https://github.com/brunch/brunch.github.io/blob/master/source/app/assets/_docs/config.md">Edit config.md on GitHub</a></span></div></div></div></div></div><footer><hr class="rule"><p><small>Hosted on <a href="https://github.com/brunch/brunch.github.com">GitHub Pages</a>. The content on this website is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/3.0/deed.en_US">CC BY 3.0</a>. Logo by <a href="http://helle.in">Michael Hellein</a></small></p><script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/highlight.min.js" defer onload="hljs.initHighlightingOnLoad()"></script><script src="/app.js" defer onload="require('init')"></script><script src="/images/svg/grunticon.loader.js" defer onload="grunticon( [ '/images/svg/icons.data.svg.css', '/images/svg/icons.data.png.css', '/images/svg/icons.fallback.css' ] )"></script><link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:400,300,600,700,400italic"><link rel="stylesheet" href="//fonts.googleapis.com/css?family=Source+Code+Pro:400,700"><link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.4.0/styles/tomorrow.min.css"><link rel="publisher" href="https://plus.google.com/+PaulMillerLi"></footer></div>  <script type="text/javascript">
     var _gauges = _gauges || [];
     (function() {

--- a/source/app/assets/_docs/config.md
+++ b/source/app/assets/_docs/config.md
@@ -457,8 +457,3 @@ Possible values:
         }
       }
     ```
-
-## Tips
-
-- You can use CoffeeScript to write configuration files. This way they'll be
-much shorter and concise. Simply create a file called `brunch-config.coffee`.


### PR DESCRIPTION
>## Tips
> You can use CoffeeScript to write configuration files. This way they'll be much shorter and concise. Simply create a file called brunch-config.coffee.