### PR TITLE
Clean up docs

### DIFF
--- a/app/assets/_docs/commands.md
+++ b/app/assets/_docs/commands.md
@@ -9,9 +9,9 @@ Create new brunch project. Full syntax: `brunch new [path] [-s skeleton]`
 
 Example:
 
-- `brunch new`: The default skeleton does not add any libraries or frameworks
-- `brunch new -s es6` would init a simple app that supports ECMAScript 6 compilation with Babel.
-- `brunch new -s react` and `brunch new -s redux` are lovely skeletons for React fans.
+* `brunch new`: The default skeleton does not add any libraries or frameworks
+* `brunch new -s es6` would init a simple app that supports ECMAScript 6 compilation with Babel.
+* `brunch new -s react` and `brunch new -s redux` are lovely skeletons for React fans.
 
 ## `brunch build` / `brunch b`
 

--- a/app/assets/_docs/concepts.md
+++ b/app/assets/_docs/concepts.md
@@ -23,7 +23,7 @@ That's all there is, really. While Brunch does assume your code is going to live
 
 The only required piece of configuration is telling Brunch which output files you want — and it couldn't be simpler:
 
-```javascript
+```js
 module.exports = {
   files: {
     javascripts: {joinTo: 'app.js'},
@@ -36,11 +36,11 @@ This will concatenate all your javascript files into `public/app.js`.
 
 If you want a little more control, like splitting your app code from vendor files into separate bundles, that's just as easy:
 
-```javascript
+```js
 module.exports = {
   files: {
     javascripts: {joinTo: {
-      'app.js': /^app/, // all code from 'app/',
+      'app.js': /^app/,       // all code from 'app/',
       'vendor.js': /^(?!app)/ // all BUT app code - 'vendor/', 'node_modules/', etc
     }},
     stylesheets: {joinTo: 'app.css'}

--- a/app/assets/_docs/concepts.md
+++ b/app/assets/_docs/concepts.md
@@ -4,9 +4,9 @@ Brunch operates on a set of assumptions about how your app is authored and compi
 
 Any Brunch **project** consists of the following:
 
-* a **config**, which allows you to customize various aspects of Brunch, as well as configure plugins (see [config reference](/docs/config.html))
+* a **config**, which allows you to customize various aspects of Brunch, as well as configure plugins (see [config reference](/docs/config))
 * **`package.json`**, which lists the plugins you want Brunch to use, as well as your app's own dependencies
-  * a **plugin** is what allows Brunch to provide any custom behavior or handle all the various JS-/CSS- transpiled languages for you (see [Using plugins](/docs/using-plugins.html) and [plugins list](/plugins.html) to get an idea)
+  * a **plugin** is what allows Brunch to provide any custom behavior or handle all the various JS-/CSS- transpiled languages for you (see [Using plugins](/docs/using-plugins) and [plugins list](/plugins) to get an idea)
 * **source files** — files that you author in your preferred language, which later get compiled into either JS or CSS
 * **assets** — files that are copied as-is (in some cases these can be compiled too, e.g. Jade &rarr; HTML)
 * **vendor files** — JS and CSS files that do not need any processing
@@ -15,9 +15,9 @@ Any Brunch **project** consists of the following:
 What Brunch does, in essence, is this:
 
 1. compile your source files using appropriate plugins
-2. concatenate several compiled source files into one
-3. write the result into a file
-4. copy assets
+1. concatenate several compiled source files into one
+1. write the result into a file
+1. copy assets
 
 That's all there is, really. While Brunch does assume your code is going to live under `app/` and your assets under `app/assets/`, and build result is put under `public/`, you are by all means free to use your own structure. Just [tell Brunch what it is](/docs/config.html#paths).
 

--- a/app/assets/_docs/config.md
+++ b/app/assets/_docs/config.md
@@ -3,19 +3,19 @@
 Brunch uses configuration file `brunch-config.js` *(or `.coffee`)* to manage various
 aspects of your app.
 
-* [**`paths`**](#-paths-) - where to take files from and where to put generated ones
-* [**`files`**](#-files-) - which files exactly should Brunch generate and how.
-* [**`npm`**](#-npm-) - NPM dependencies settings
-* [**`plugins`**](#-plugins-) - individual plugin settings.
+* [**`paths`**](#-paths-) — where to take files from and where to put generated ones
+* [**`files`**](#-files-) — which files exactly should Brunch generate and how.
+* [**`npm`**](#-npm-) — NPM dependencies settings
+* [**`plugins`**](#-plugins-) — individual plugin settings.
 
 Less common options:
 
-* [`modules`](#-modules-) - specifies details of JS module implementation, such as `wrapper`, `definition`, `autoRequire` and `nameCleaner`.
-* [`conventions`](#-conventions-) - defines which files are treated as assets and which ones are ignored in your app.
-* [`watcher`](#-watcher-) - low-level configuration of the file watcher which empowers Brunch.
-* [`server`](#-server-) - allows to describe custom web-servers instead of the built-in one.
-* `sourceMaps`, `optimize`, `notifications`, `notificationsTitle` - simple true/false options
-* [`hooks`](#-hooks-) - allows to specify handlers for different moments of building cycle
+* [`modules`](#-modules-) — specifies details of JS module implementation, such as `wrapper`, `definition`, `autoRequire` and `nameCleaner`.
+* [`conventions`](#-conventions-) — defines which files are treated as assets and which ones are ignored in your app.
+* [`watcher`](#-watcher-) — low-level configuration of the file watcher which empowers Brunch.
+* [`server`](#-server-) — allows to describe custom web-servers instead of the built-in one.
+* `sourceMaps`, `optimize`, `notifications`, `notificationsTitle` — simple true/false options
+* [`hooks`](#-hooks-) — allows to specify handlers for different moments of building cycle
 
 <span class="note">
   You can see the config schema, and all the defaults, in the `configBaseSchema` of [`lib/utils/config-validate.js`](https://github.com/brunch/brunch/blob/master/lib/utils/config-validate.js#L9) in the Brunch source code.
@@ -110,18 +110,18 @@ Also, consider [`module.nameCleaner` option](#-modules-), if you need to require
 `Required, object`: `files` configures handling of application files: which compiler would be used on which file, what name should output file have etc. Any paths specified here must be listed in `paths.watched` as described above, for building.
 
 * `<type>`: `javascripts`, `stylesheets` or `templates`
-    * joinTo: (required) describes how files will be compiled & joined together.
-      Available formats:
-        * `'outputFilePath'` in order to have all source files compiled together to one
-        * map of `'outputFilePath'` (see [Pattern matching](#pattern-matching) section)
-    * entryPoints: (optional) describes the entry points of an application. The specified file and all of its dependencies will then be joined into a single file. Resembles `joinTo` but allows to included only the files you need.
-      Available formats:
-        * `'entryFile.js': 'outputFilePath'`
-        * `'entryFile.js':` map of `'outputFilePath'` (see [Pattern matching](#pattern-matching) section)
-    * order: (optional) defines compilation order. `vendor` files will be compiled before other ones even if they are not present here.
-        * before: [matching pattern](#pattern-matching) defining files that will be loaded before other files
-        * after: [matching pattern](#pattern-matching) defining files that will be loaded after other files
-    * pluginHelpers: (optional) specify which output file (or array of files) plugins' include files concatenate into. Defaults to the output file that `vendor` files are being joined to, the first one with `vendor` in its name/path, or just the first output file listed in your joinTo object.
+  - joinTo: (required) describes how files will be compiled & joined together.
+    Available formats:
+    + `'outputFilePath'` in order to have all source files compiled together to one
+    + map of `'outputFilePath'` (see [Pattern matching](#pattern-matching) section)
+  - entryPoints: (optional) describes the entry points of an application. The specified file and all of its dependencies will then be joined into a single file. Resembles `joinTo` but allows to included only the files you need.
+    Available formats:
+    + `'entryFile.js': 'outputFilePath'`
+    + `'entryFile.js':` map of `'outputFilePath'` (see [Pattern matching](#pattern-matching) section)
+  - order: (optional) defines compilation order. `vendor` files will be compiled before other ones even if they are not present here.
+    + before: [matching pattern](#pattern-matching) defining files that will be loaded before other files
+    + after: [matching pattern](#pattern-matching) defining files that will be loaded after other files
+  - pluginHelpers: (optional) specify which output file (or array of files) plugins' include files concatenate into. Defaults to the output file that `vendor` files are being joined to, the first one with `vendor` in its name/path, or just the first output file listed in your joinTo object.
 
 All files from `vendor` directory are by default concatenated before all files from `app` directory. So, `vendor/scripts/jquery.js` would be loaded before `app/script.js` even if order config is empty. Files from Bower packages are included by default before the `vendor` files.
 
@@ -150,10 +150,10 @@ files: {
 
 It is important to keep a few things in mind regarding entry points & their known limitations:
 
-* only the things you `require` will be included into an entryPoint bundle. This means non-app/non-npm deps won't be included. Also means only statically analyzable `require`s will work:
-  * `require('something')` — :+1:
-  * `['a', 'b', 'c'].forEach(dep => require(dep))` — :-1:
-  * `match('/', 'app/Home')` (where `app/Home` gets translated into `require('components/app/Home')`) — :-1:
+* only the things you `require` will be included into an entryPoint bundle. This means non-app/non-npm dependencie won't be included. Also means only statically analyzable `require`s will work:
+  - `require('something')` — :+1:
+  - `['a', 'b', 'c'].forEach(dep => require(dep))` — :-1:
+  - `match('/', 'app/Home')` (where `app/Home` gets translated into `require('components/app/Home')`) — :-1:
 * two entry points can't write to the same file
 
   ```javascript
@@ -449,14 +449,14 @@ Possible values:
     }
     ```
 * `onCompile` - `Function`: Optional callback to be called every time brunch completes a compilation cycle. It is passed a `generatedFiles` array, as well as `changedAssets` array. Each member of `generatedFiles` array is an object with:
-    * `path` — path of the compiled file
-    * `sourceFiles` — array of objects representing each source file
-    * `allSourceFiles` array of objects representing each source file — this one also includes files that don't belong to the original type (e.g. if a styles compiler adds a JS module, path would the the concated JS file, and one of the `allSourceFiles` will be a style file
+  - `path` — path of the compiled file
+  - `sourceFiles` — array of objects representing each source file
+  - `allSourceFiles` array of objects representing each source file — this one also includes files that don't belong to the original type (e.g. if a styles compiler adds a JS module, path would be the concatenated JS file, and one of the `allSourceFiles` will be a style file
 
     Each member of `changedAssets` array is an object with:
 
-    * `path` — original path of an asset
-    * `destinationPath` — path of an asset in the public directory
+  - `path` — original path of an asset
+  - `destinationPath` — path of an asset in the public directory
 
     Example:
 

--- a/app/assets/_docs/config.md
+++ b/app/assets/_docs/config.md
@@ -25,7 +25,7 @@ Less common options:
 
 Simplest Brunch config looks like that. Just 7 lines of pure configuration:
 
-```javascript
+```js
 module.exports = {
   files: {
     javascripts: {joinTo: 'app.js'},
@@ -44,21 +44,21 @@ Internally, Brunch uses [anymatch](https://github.com/es128/anymatch) for patter
 
 * **String** — path to your source files to be directly matched. You can use [globs](https://en.wikipedia.org/wiki/Glob_(programming)), so these strings may contain [wildcard characters](https://en.wikipedia.org/wiki/Wildcard_character) (`*`, `?`, etc). Example:
 
-  ```javascript
+  ```js
   joinTo: {
     'app.css': 'path/to/*.css' // matches all CSS files
   }
   ```
 * **Regular expression** — feel free to define a pattern using regular expression if you used to. Example:
 
-  ```javascript
+  ```js
   joinTo: {
     'app.js': /\.js$/ // matches all JavaScript files
   }
   ```
 * **Function** — if you need especially specific pattern, you can define it using function that takes the string as an argument and returns a truthy or falsy value (like `Array.filter` function do). Example:
 
-  ```javascript
+  ```js
   joinTo: {
     // matches all JavaScript files with filenames longer that 3 characters
     'app.js': path => path.endsWith('.js') && path.length > 3
@@ -66,7 +66,7 @@ Internally, Brunch uses [anymatch](https://github.com/es128/anymatch) for patter
   ```
 * **Array** — an array of any number and mix of the above types. Example:
 
-  ```javascript
+  ```js
   joinTo: {
     'app.js': [
       'path/to/specific/file.js',   // include specific file
@@ -87,7 +87,7 @@ Internally, Brunch uses [anymatch](https://github.com/es128/anymatch) for patter
 
 Example:
 
-```javascript
+```js
 paths: {
   public: '/user/www/deploy'
 }
@@ -129,7 +129,7 @@ Overall ordering is [before] -> [bower] -> [vendor] -> [everything else] -> [aft
 
 Common example:
 
-```javascript
+```js
 files: {
   javascripts: {
     joinTo: {
@@ -156,12 +156,12 @@ It is important to keep a few things in mind regarding entry points & their know
   - `match('/', 'app/Home')` (where `app/Home` gets translated into `require('components/app/Home')`) — :-1:
 * two entry points can't write to the same file
 
-  ```javascript
+  ```js
   javascripts: {
     entryPoints: {
-      'app/initialize.coffee': 'javascripts/bundle.js',
+      'app/initialize.js': 'javascripts/bundle.js',
       // INVALID
-      'app/bookmarklet.coffee': 'javascripts/bundle.js'
+      'app/bookmarklet.js': 'javascripts/bundle.js'
     }
   }
   ```
@@ -170,7 +170,7 @@ It is important to keep a few things in mind regarding entry points & their know
 
 ## `npm`
 
-`Object`: configures NPM integration for front-end packages. Make sure you also declare the packages you depend on in your package.json `dependencies` section.
+`Object`: configures NPM integration for front-end packages. Make sure you also declare the packages you depend on in your `package.json` dependencies section.
 
 * `npm.enabled`: `Boolean`: a toggle of whether the integration is enabled, defaults to `true`.
 * `npm.globals`: `Object`: a mapping from global name (as a key) to the corresponding module name (string) to expose.
@@ -180,7 +180,7 @@ It is important to keep a few things in mind regarding entry points & their know
 
 Example:
 
-```javascript
+```js
 npm: {
   styles: {pikaday: ['css/pikaday.css']},
   globals: {Pikaday: 'pikaday'}
@@ -199,7 +199,7 @@ npm: {
 
 Example:
 
-```javascript
+```js
 plugins: {
   on: ['postcss-brunch'],
   off: ['jade-brunch', 'handlebars-brunch'],
@@ -223,7 +223,7 @@ Example:
 ```javascript
 conventions: {
   ignored: () => false, // override defaults for no ignored files
-  assets: /files\//  // vendor/jquery/files/jq.img
+  assets: /files\//     // vendor/jquery/files/jq.img
 }
 ```
 
@@ -248,7 +248,7 @@ You may find default values for `ignored`, `assets` and `vendor` fields in [Brun
 
 Example:
 
-```javascript
+```js
 // Same as 'commonjs'.
 modules: {
   wrapper: (path, data) => {
@@ -262,7 +262,7 @@ require.define({${path}: function(exports, require, module) {
 ```
 `modules.autoRequire`: `Object` specifies requires to be automatically added at the end of joined file. The example below will require both 'app' and 'foo':
 
-```javascript
+```js
 // Default behaviour.
 modules: {
   autoRequire: {
@@ -274,14 +274,14 @@ modules: {
 `modules.nameCleaner`: `Function` Allows you to set filterer function for module names,
 for example, change all 'app/file' to 'file'. Example:
 
-```javascript
+```js
 // Default behaviour.
 modules: {
   nameCleaner: path => path.replace(/^app\//, '')
 }
 ```
 
-```javascript
+```js
 // Add namespacing to a project.
 const {name} = require('./package.json');
 modules: {
@@ -291,7 +291,7 @@ modules: {
 
 Also `nameCleaner` option may help you when you need to change the default directory for app code to `src`, for example:
 
-```javascript
+```js
 modules: {
   nameCleaner: path => path.replace(/^src\//, '')
 }
@@ -321,11 +321,11 @@ When set to `true`, only errors trigger notifications. If you want to display su
 
 `Object`: contains params of webserver that runs on `brunch watch --server`.
 
-If a `brunch-server.js` or `brunch-server.coffee` file exists at the root of your project, Brunch will treat this as your custom web server. This can be overriden with the `server.path` option.
+If a `brunch-server.js` or `brunch-server.coffee` file exists at the root of your project, Brunch will treat this as your custom web server. This can be overridden with the `server.path` option.
 
 The server script must export a function that starts your custom server, either as the default exported module. This function should return an instance of [`http.Server`](https://nodejs.org/api/http.html#http_class_http_server) or an object containing a `close` property assigned to a function that shuts down the server. Examples:
 
-```javascript
+```js
 // javascript example using default export and node http core module
 module.exports = (port, path, callback) => {
   // your custom server code
@@ -338,7 +338,7 @@ module.exports = (port, path, callback) => {
 };
 ```
 
-```javascript
+```js
 // Example using custom `close` method.
 module.exports = (port, path, callback) => {
   // custom server code
@@ -362,7 +362,7 @@ If a custom server is not present, Brunch will use [pushserve](https://github.co
 
 Example:
 
-```javascript
+```js
 server: {
   port: 6832,
   base: '/myapp',
@@ -405,7 +405,7 @@ BRUNCH_ENV="testing" brunch build
 
 Defaults:
 
-```javascript
+```js
 overrides: {
   production: {
     optimize: true,
@@ -426,10 +426,10 @@ In other words, `joinTo` and `order` don't merge if defined under `overrides`, b
 
 `Object`: Optional settings for
 [chokidar](https://github.com/paulmillr/chokidar)
-file watching library used in brunch.
+file watching library used in Brunch.
 
-* `usePolling` (default: `false`) Whether to use fs.watchFile
-    (backed by polling), or fs.watch.
+* `usePolling` (default: `false`) Whether to use `fs.watchFile`
+    (backed by polling), or `fs.watch`.
     Polling is slower but can be more reliable.
 
 ## `hooks`

--- a/app/assets/_docs/config.md
+++ b/app/assets/_docs/config.md
@@ -1,7 +1,6 @@
 # Brunch: Config
 
-Brunch uses configuration file `brunch-config.js` *(or `.coffee`)* to manage various
-aspects of your app.
+Brunch uses configuration file `brunch-config.js` _(or `.coffee`)_ to manage various aspects of your app.
 
 * [**`paths`**](#-paths-) — where to take files from and where to put generated ones
 * [**`files`**](#-files-) — which files exactly should Brunch generate and how.
@@ -348,7 +347,7 @@ module.exports = (port, path, callback) => {
 }
 ```
 
-* `path`: (optional) custom path to nodejs file that will be loaded to run your custom server.
+* `path`: (optional) custom path to Node.js file that will be loaded to run your custom server.
 
 If a custom server is not present, Brunch will use [pushserve](https://github.com/paulmillr/pushserve). If using your own, only `port` from the following options can be set from the config.
 
@@ -370,7 +369,7 @@ server: {
 }
 ```
 
-* `command`: command to launch a non-nodejs server as a child process. Ex: `server: command: 'php -S 0.0.0.0:3000 -t public'`
+* `command`: command to launch a non-Node.js server as a child process. Ex: `server: command: 'php -S 0.0.0.0:3000 -t public'`
 
 ## `sourceMaps`
 
@@ -453,22 +452,22 @@ Possible values:
   - `sourceFiles` — array of objects representing each source file
   - `allSourceFiles` array of objects representing each source file — this one also includes files that don't belong to the original type (e.g. if a styles compiler adds a JS module, path would be the concatenated JS file, and one of the `allSourceFiles` will be a style file
 
-    Each member of `changedAssets` array is an object with:
+  Each member of `changedAssets` array is an object with:
 
   - `path` — original path of an asset
   - `destinationPath` — path of an asset in the public directory
 
-    Example:
+  Example:
 
-    ```javascript
-      hooks: {
-        onCompile(generatedFiles, changedAssets) {
-          console.log(generatedFiles.map(f => f.path));
-        }
+  ```javascript
+    hooks: {
+      onCompile(generatedFiles, changedAssets) {
+        console.log(generatedFiles.map(f => f.path));
       }
-    ```
+    }
+  ```
 
 ## Tips
 
-- You can use CoffeeScript to write configuration files. This way they'll be
+You can use CoffeeScript to write configuration files. This way they'll be
 much shorter and concise. Simply create a file called `brunch-config.coffee`.

--- a/app/assets/_docs/deploying.md
+++ b/app/assets/_docs/deploying.md
@@ -19,7 +19,7 @@
     directory to the directory that is served by a webserver.
   </li>
   <li>
-    If you use <strong>hosting that supports node.js</strong>, you can
+    If you use <strong>hosting that supports Node.js</strong>, you can
     install brunch there and auto-build app every time.
   </li>
   <li>

--- a/app/assets/_docs/getting-started.md
+++ b/app/assets/_docs/getting-started.md
@@ -18,7 +18,7 @@ Let's try to create a new app from it!
 
 Type
 
-```bash
+```sh
 $ brunch new proj -s es6
 ```
 
@@ -31,7 +31,7 @@ $ brunch new proj -s es6
 
 After the project is created, let's try to build it:
 
-```bash
+```sh
 $ brunch build
 01 Apr 10:45:30 - info: compiled initialize.js into app.js, copied index.html in 857ms
 ```
@@ -60,7 +60,7 @@ public/             // The "output" Brunch will re-generate on every build.
 
 Let's add a few files to our app, then build the app one more time:
 
-```bash
+```sh
 $ echo "body {font-family: 'Comic Sans MS'}" > app/main.css
 $ echo "console.log('Hello, world')" > app/logger.js
 $ brunch build
@@ -94,7 +94,7 @@ jQuery to our app - we'll need to use it somewhere too.
 
 Add the following code anywhere in `initialize.js`:
 
-```javascript
+```js
 var $ = require('jquery');
 console.log('Tasty Brunch, just trying to use jQuery!', $('body'));
 ```

--- a/app/assets/_docs/getting-started.md
+++ b/app/assets/_docs/getting-started.md
@@ -8,7 +8,7 @@
 
 ## Tasting your first Brunch
 
-So, you've installed node.js and brunch itself (`npm install -g brunch`).
+So, you've installed Node.js and brunch itself (`npm install -g brunch`).
 You're probably starving at this point. Let's get *straight to the business*.
 
 `brunch new` helps to init new Brunch project from one of
@@ -74,15 +74,9 @@ Let's inspect files in `public` to understand what happened at this point:
 
 ## Serving the Brunch
 
-Executing `brunch build` every time seems to take too much effort. Instead, let's
-just do `brunch watch --server`. The `watch` would **automatically & efficiently rebuild the
-app on every change**. `--server` flag would also launch a HTTP server. The default
-location for the server is [`http://localhost:3333`](http://localhost:3333), so open this URL in a browser
-of your choice. You'll see our app and everything which was located in `public`
-directory.
+Executing `brunch build` every time seems to take too much effort. Instead, let's just do `brunch watch --server`. The `watch` would **automatically & efficiently rebuild the app on every change**. `--server` flag would also launch a HTTP server. The default location for the server is [`http://localhost:3333`](http://localhost:3333), so open this URL in a browser of your choice. You'll see our app and everything which was located in `public` directory.
 
-Since the shell console would be busy with `brunch watch` command, we'll need
-to open a new window.
+Since the shell console would be busy with `brunch watch` command, we'll need to open a new window.
 
 ## Including third-party ingredients
 

--- a/app/assets/_docs/getting-started.md
+++ b/app/assets/_docs/getting-started.md
@@ -69,10 +69,8 @@ $ brunch build
 
 Let's inspect files in `public` to understand what happened at this point:
 
-- `app.css` simply has content of `app/main.css` and nothing else
-- `app.js` has require definition and contents of both `initialize.js` and `logger.js`.
-  Each file is wrapped into a JS function, which defines a module. This
-  allows us to do things like `require('./logger')`.
+* `app.css` simply has content of `app/main.css` and nothing else
+* `app.js` has require definition and contents of both `initialize.js` and `logger.js`. Each file is wrapped into a JS function, which defines a module. This allows us to do things like `require('./logger')`.
 
 ## Serving the Brunch
 

--- a/app/assets/_docs/plugins.md
+++ b/app/assets/_docs/plugins.md
@@ -9,18 +9,18 @@ Brunch plugins are plain JS classes which are initialized with brunch configs.
 Almost every plugin is usually working with so-called `File` entities:
 
 ```json
-{"data": "var hello = 42;\n", "path": "app/file.js"}
+{
+  "data": "var hello = 42;\n",
+  "path": "app/file.js"
+}
 ```
 
 As you can see, `File`s are bald JS `Object`s, which may contain fields like:
 
-- `path` - system path to the file
-- `data` - file data as JS `String`
-- `map` - source map
-- and anything else that could be consumed by next plugins.
-  For example, the linter plugin may add `babelTree` to the `File`,
-  the compiler plugin in pipeline would see it and won't do the parsing twice.
-  (Though this will not work with parallelized build.)
+* `path` - system path to the file
+* `data` - file data as JS `String`
+* `map` - source map
+* and anything else that could be consumed by next plugins. For example, the linter plugin may add `babelTree` to the `File`, the compiler plugin in pipeline would see it and won't do the parsing twice. (Though this will not work with parallelized build.)
 
 ### Pipeline
 
@@ -337,5 +337,4 @@ This will make more people aware of it.
 
 ## Tips
 
-- Make Brunch plugins as simple as possible. Don't try to copy Grunt, Gulp or other
-  task runners approaches.
+Make Brunch plugins as simple as possible. Don't try to copy Grunt, Gulp or other task runners approaches.

--- a/app/assets/_docs/plugins.md
+++ b/app/assets/_docs/plugins.md
@@ -1,6 +1,6 @@
 # Brunch: Plugin API
 
-Brunch plugins are plain JS classes which are initialized with brunch configs.
+Brunch plugins are plain JS classes which are initialized with Brunch configs.
 
 <div class="toc-placeholder"></div>
 
@@ -254,7 +254,7 @@ UglifyOptimizer.prototype.extension = 'js';
 module.exports = UglifyOptimizer;
 ```
 
-See the [plugins page](http://brunch.io/plugins.html) for a list of plugins. Feel free to add new plugins by editing [plugins.json](https://github.com/brunch/brunch.github.io/blob/master/plugins.json) and sending a Pull Request.
+See the [plugins page](http://brunch.io/plugins) for a list of plugins. Feel free to add new plugins by editing [plugins.json](https://github.com/brunch/brunch.github.io/blob/master/plugins.json) and sending a Pull Request.
 
 ### Exporting JS from stylesheets
 

--- a/app/assets/_docs/plugins.md
+++ b/app/assets/_docs/plugins.md
@@ -137,7 +137,7 @@ If `pattern` was specified, everything pattern matches will be replaced with `st
 
 Let's take a look at the [boilerplate plugin](https://github.com/brunch/brunch-boilerplate-plugin). Feel free to use it to create your own plugins:
 
-```javascript
+```js
 'use strict';
 
 // Documentation for Brunch plugins:
@@ -149,7 +149,7 @@ class BrunchPlugin {
     // Replace 'plugin' with your plugin's name;
     this.config = config.plugins.plugin;
   }
-  
+
   // Optional
   // Specifies additional files which will be included into build.
   // get include() { return ['path-to-file-1', 'path-to-file-2']; }
@@ -208,7 +208,7 @@ module.exports = BrunchPlugin;
 
 The plugin would simply read the file and return its contents.
 
-```javascript
+```js
 class CSSCompiler {
   compile(file) {
     return Promise.resolve(file);
@@ -226,7 +226,7 @@ module.exports = CSSCompiler;
 
 An abstract minifier that consumes source maps.
 
-```javascript
+```js
 class UglifyOptimizer {
   constructor(config) {
     this.config = config.plugins.uglify;
@@ -267,8 +267,8 @@ A use case could be a styles compiler with CSS modules support that allows you t
   margin: 0
 ```
 
-```javascript
-var style = require('./button.styl');
+```js
+const style = require('./button.styl');
 // ...
 
 // style.button will return the obfuscated class name (something like "_button_xkplk_42" perhaps)
@@ -277,7 +277,7 @@ var style = require('./button.styl');
 
 All compiler needs to do is return `exports` in addition to `{data, map}`:
 
-```javascript
+```js
 class MyCompiler {
   compile({data, path}) {
     const compiled = magic(data);
@@ -300,7 +300,7 @@ Previously, what you would do in this case was to hook into `onCompile` and look
 
 So starting Brunch `2.8.0`, there is a better way.
 
-```javascript
+```js
 class JadeCompiler {
   compileStatic({data, path}) {
     return new Promise((resolve, reject) => {

--- a/app/assets/_docs/testing.md
+++ b/app/assets/_docs/testing.md
@@ -18,8 +18,8 @@ For integration testing in the browser, there are no additional steps required.
 
 This simple function will load all your files that are ending with the `-test` suffix (`user-view-test.coffee` etc).
 
-```javascript
+```js
 window.require.list()
-  .filter(function(name) {return /-test$/.test(name);})
+  .filter(name => /-test$/.test(name))
   .forEach(require);
 ```

--- a/app/assets/_docs/troubleshooting.md
+++ b/app/assets/_docs/troubleshooting.md
@@ -28,7 +28,7 @@ Here's a quick summary on how to fix this:
 
 * try add this to your config:
 
-  ```javascript
+  ```js
   watcher: {
     awaitWriteFinish: true,
     usePolling: true

--- a/app/assets/_docs/troubleshooting.md
+++ b/app/assets/_docs/troubleshooting.md
@@ -16,7 +16,11 @@ If you are running `brunch watch` and change something, to later find out that t
 
 It is caused by the way some editors write to files.
 It also can happen when you edit files over ssh.
-You can see these threads for more details: https://github.com/brunch/brunch/issues/1250 https://github.com/brunch/brunch/issues/1219 https://github.com/brunch/brunch/issues/1303
+You can see these threads for more details:
+
+* [brunch/brunch#1250](https://github.com/brunch/brunch/issues/1250)
+* [brunch/brunch#1219](https://github.com/brunch/brunch/issues/1219)
+* [brunch/brunch#1303](https://github.com/brunch/brunch/issues/1303)
 
 Here's a quick summary on how to fix this:
 

--- a/app/assets/_docs/troubleshooting.md
+++ b/app/assets/_docs/troubleshooting.md
@@ -3,6 +3,7 @@
 <div class="toc-placeholder"></div>
 
 <a name="emfile"></a>
+
 ## I get an EMFILE error when I build a Brunch project
 
 `EMFILE` means there are too many open files.

--- a/app/assets/_docs/using-modules.md
+++ b/app/assets/_docs/using-modules.md
@@ -101,11 +101,11 @@ files: {
 }
 ```
 
-Note that for other assets that come from NPM packages (like images, fonts, etc), you will have to manually copy them to your public folder. You can use the npm's `postinstall` hook to do the copying. See [FAQ](/docs/faq.html).
+Note that for other assets that come from NPM packages (like images, fonts, etc), you will have to manually copy them to your public folder. You can use the npm's `postinstall` hook to do the copying. See [FAQ](/docs/faq).
 
 ### Making packages global
 
-It's possible to expose npm packages to `window` — so that you can access the module without requiring it. See [docs](/docs/config.html#-npm-).
+It's possible to expose npm packages to `window` — so that you can access the module without requiring it. See [docs](/docs/config#-npm-).
 
 ## Hot Module Replacement
 

--- a/app/assets/_docs/using-modules.md
+++ b/app/assets/_docs/using-modules.md
@@ -12,7 +12,7 @@ To make things a bit nicer, Brunch cuts the `app` portion from the module name.
 For example, `app/config.js` will have a module name of `config.js`.
 With CommonJS, your modules will return values by putting them into `module.exports`, just like you would with Node.
 
-```javascript
+```js
 // app/config.js
 module.exports = {
   api: {
@@ -23,8 +23,8 @@ module.exports = {
 
 To use it in other modules, just `require` it! Note that you can require using both a name with extension (like `config.js`) or a name without extension (`config`):
 
-```javascript
-var config = require('config');
+```js
+const config = require('config');
 
 makeRequest(config.api, 'GET', 'plugins');
 ```
@@ -36,7 +36,7 @@ You can do it by either:
 * adding `<script>require('initialize');</script>` — where `initialize` is the name of the entry module (which would be located in `app/initialize.js`); **OR**
 * adding an [`autoRequire`](/docs/config#-modules-) to config, to make Brunch do the above for you:
 
-  ```javascript
+  ```js
   // brunch-config
   module.exports = {
     modules: {
@@ -70,7 +70,7 @@ Simply `npm install --save` your front-end packages as you normally would, `requ
 
 Just make sure that you don't forget to join `/^node_modules/` somewhere!
 
-```javascript
+```js
 files: {
   javascripts: {
     joinTo: {
@@ -85,8 +85,12 @@ files: {
 
 Brunch can also handle styles of client-side libraries, by providing `styles` attribute which is key-value object where key is package name and value is an array with relative to package path of styles which should be included.
 
-```javascript
-npm: {styles: {leaflet: ['dist/leaflet.css']}},
+```js
+npm: {
+  styles: {
+    leaflet: ['dist/leaflet.css']
+  }
+},
 files: {
   javascripts: {
     joinTo: {'js/vendor.js': /^node_modules/}

--- a/app/assets/_docs/using-plugins.md
+++ b/app/assets/_docs/using-plugins.md
@@ -47,7 +47,7 @@ Refer to the plugin's `README` on details regarding configuration.
 
 Typically it would go under the `config.plugins.<plugin>`:
 
-```javascript
+```js
 module.exports = {
   plugins: {
     babel: {
@@ -87,8 +87,8 @@ Which gets turned into something like:
 
 To make your JS component aware of the actual class name, a compiler can allow you to `require` that css file to get information about its class name mappings:
 
-```javascript
-var style = require('./button.styl');
+```js
+const style = require('./button.styl');
 // ...
 
 // style.button will return the obfuscated class name (something like "_button_xkplk_42" perhaps)

--- a/app/assets/_docs/using-plugins.md
+++ b/app/assets/_docs/using-plugins.md
@@ -1,6 +1,6 @@
 # Brunch: Using plugins
 
-Brunch uses node.js plugins to provide compilation / linting / optimization functionality.
+Brunch uses Node.js plugins to provide compilation / linting / optimization functionality.
 
 Brunch has a plugin ecosystem to achieve interoperability with various tools simply via [plugin API](/docs/plugins.html).
 
@@ -25,7 +25,7 @@ Brunch plugins can fall into three broad categories (one plugin can belong to se
   As the name implies, they optimize compiled JS or CSS files.
   Examples of optimizers include: a JavaScript uglifier; a CSS prefixer and minifier.
 
-You can browse some of the community-supported plugins in the [Plugins](/plugins.html) section.
+You can browse some of the community-supported plugins in the [Plugins](/plugins) section.
 
 ## Installation
 

--- a/app/assets/_docs/using-plugins.md
+++ b/app/assets/_docs/using-plugins.md
@@ -105,5 +105,4 @@ Starting with Brunch 2.8, this is made available for plugins to implement.
 
 ## Tips
 
-- Don't include plugins for languages or technologies your app does not use.
-  They may unnecessarily slowdown the build process.
+Don't include plugins for languages or technologies your app does not use. They may unnecessarily slowdown the build process.

--- a/app/assets/_docs/why-brunch.md
+++ b/app/assets/_docs/why-brunch.md
@@ -14,7 +14,7 @@ Even more so if you run the watcher — it will only rebuild what was changed, n
 (Obviously, you don't have to take our word for it. See [this story](https://github.com/brunch/brunch/issues/1234) shared with us by a webpack user.)
 
 In order to achieve both goals, Brunch does have to make certain assumptions about your application, and thus be opinionated.
-See the [core concepts page](/docs/concepts.html) for more on this.
+See the [core concepts page](/docs/concepts) for more on this.
 
 Besides configs, brunch is also **simpler in terms of commands**.
 Grunt / Gulp commands replicate all plugins it loads.

--- a/app/assets/_docs/why-brunch.md
+++ b/app/assets/_docs/why-brunch.md
@@ -58,7 +58,7 @@ But even then, your rebuilds during `watch` won't be incremental — they will a
 
 With Asset pipeline there are similar disadvantages. With Brunch:
 
-- You can use any backend you like, be it node.js, Rails or Lift. You can even keep frontend and backend as separate projects.
-- You'll get automated module support
-- You'll have NPM & Bower support
-- Rebuilds would be fast and incremental
+* You can use any backend you like, be it Node.js, Rails or Lift. You can even keep frontend and backend as separate projects.
+* You'll get automated module support
+* You'll have NPM & Bower support
+* Rebuilds would be fast and incremental


### PR DESCRIPTION
* easier to change order or add new items whet all of them has `1.` as index
* `javascript` -> `js`, cause it's shorter and universal
* clean-up links
* `_italic_` and `**bold**` everywhere
* Remove mentions of `coffee` from examples
* Fix mistakes in words
* Consist *tips* sections