### PR TITLE
Fix firefox broken plugins page

### DIFF
--- a/app/plugins.jsx
+++ b/app/plugins.jsx
@@ -62,14 +62,12 @@ var Body = React.createClass({
 
   categorySortedPlugins: function() {
     var sorting = ['Compilers', 'Minifiers', 'Linters', 'Graphics', 'Others'];
-    var subSorting = { 'Compilers': ['Script languages', 'Style languages', 'Pre-compiled templates'] };
-
     var catPlugins = this.groupedPlugins();
 
     catPlugins = catPlugins.map(function(cat) {
       return {
         category: cat.category,
-        subcategories: cat.subcategories.sort(subSorting[cat.category] || [], 'subcategory')
+        subcategories: cat.subcategories
       };
     });
 


### PR DESCRIPTION
Right now http://brunch.io/plugins doesn't work properly in firefox (v50.1.0). List of plugins is not shown. 
In console `TypeError: wrappedCompareFn is not a function`. 
Turns out that problem with https://github.com/brunch/brunch.github.io/blob/source/app/plugins.jsx#L72.
It's redundant. After removing, locally (in firefox) there are the same list as on live (in chrome).