### PR TITLE
Add pegjs-brunch to plugin list

### DIFF
--- a/app/assets/plugins.json
+++ b/app/assets/plugins.json
@@ -626,6 +626,13 @@
       "url": "roperzh/grunticon-brunch",
       "category": "Others",
       "description": "<a href=\"https://github.com/roperzh/grunticon-brunch\">grunticon-brunch</a> adds <a href=\"https://github.com/filamentgroup/grunticon-lib\">Grunticon</a> support to Brunch."
+    },
+    {
+      "name": "pegjs-brunch",
+      "url": "caleb531/pegjs-brunch",
+      "category": "Compilers",
+      "subcategory": "Script languages",
+      "description": "Adds support for <a href=\"https://github.com/pegjs/pegjs\">PEG.js</a>, a parser generator for JavaScript."
     }
   ]
 }


### PR DESCRIPTION
Hi,

I've just created [this awesome new Brunch plugin](https://github.com/caleb531/pegjs-brunch) which adds support for the JavaScript parser generator, [PEG.js](https://github.com/pegjs/pegjs). This PR adds my plugin to the Brunch plugins page.

Thanks,
Caleb