### PR TITLE
Add imagemin-brunch

### DIFF
--- a/app/assets/plugins.json
+++ b/app/assets/plugins.json
@@ -635,6 +635,12 @@
       "url": "FaKeller/kss-brunch",
       "category": "Others",
       "description": "Integrate <a href=\"https://github.com/kss-node/kss-node\">kss-node</a> to generate a living style guide from <a href=\"http://warpspire.com/kss/\">KSS</a> documentation."
+    },
+    {
+      "name": "imagemin-brunch",
+      "url": "stawberri/imagemin-brunch",
+      "category": "Minifiers",
+      "description": "Minify images with <a href=\"https://github.com/imagemin/imagemin\">imagemin</a>."
     }
   ]
 }


### PR DESCRIPTION
I noticed that there was already an [existing image optimization plugin](https://github.com/steffenmllr/imageoptmizer-brunch), but [this issue](https://github.com/steffenmllr/imageoptmizer-brunch/issues/13#issuecomment-248855295) seems to suggest that it doesn't work anymore and the writer is unable to continue working on it.

I've been using [imagemin's cli](https://github.com/imagemin/imagemin-cli) for a while, so I thought I'd try writing it into a plugin~ 😄 