### PR TITLE
Correct order of plugin execution pipeline

### DIFF
--- a/app/assets/_docs/plugins.md
+++ b/app/assets/_docs/plugins.md
@@ -35,11 +35,11 @@ watch(files)
 // Check whether the file is correct.
 lint(file): Boolean
 |
-// Extract file's dependants & dependencies
-getDependencies(file): Array[Path]
-|
 // Transform file contents into js, css etc.
 compile(file): File
+|
+// Extract file's dependants & dependencies
+getDependencies(file): Array[Path]
 |
 // [internal] wrap file into a module definition
 wrap(file): File


### PR DESCRIPTION
I was trying to setup dependency tracking for elm-lang-brunch, and I couldn't get `getDependencies` to work like I wanted. After digging around in the brunch source code, I came upon the [`compile`](https://github.com/brunch/brunch/blob/e366693a5e37d9296b4c751e67d8a8c518f32a57/lib/fs_utils/pipeline.js#L98-L124) function.

My problem was caused by the `compile` step being executed _before_ `getDependencies`, and not after as the documentation stated. I find it hard to believe that this is a bug, so I opted to update the documentation instead.