### PR TITLE
Remove replacer-brunch from list of plugins

### DIFF
--- a/app/assets/plugins.json
+++ b/app/assets/plugins.json
@@ -13,12 +13,6 @@
       "description": "Adds spritesheet-js support to brunch"
     },
     {
-      "name": "replacer-brunch",
-      "url": "tkesgar/replacer-brunch",
-      "category": "Compilers",
-      "description": "Ruthlessly simple string replacement plugin to Brunch."
-    },
-    {
       "name": "brunch-tumblr-theme-parser",
       "url": "silbinarywolf/brunch-tumblr-theme-parser",
       "category": "Compilers",


### PR DESCRIPTION
Remove replacer-brunch plugin because it is not maintained anymore.